### PR TITLE
Fix syntax errors in Discord.Net snippet

### DIFF
--- a/src/snippets/discordnet.js
+++ b/src/snippets/discordnet.js
@@ -66,7 +66,7 @@ export default {
             result[result.length-1] += ';';
 
             result.push('var embed = builder.Build();');
-            result.push(`await Context.Channel.SendMessageAsync(${data.content ? JSON.stringify(data.content) : 'null'}, embed)\n\t.ConfigureAwait(false);`);
+            result.push(`await Context.Channel.SendMessageAsync(\n\t${data.content ? JSON.stringify(data.content) : 'null'},\n\tembed: embed)\n\t.ConfigureAwait(false);`);
 
             return result.join('\n');
         } else {

--- a/src/snippets/discordnet.js
+++ b/src/snippets/discordnet.js
@@ -21,7 +21,7 @@ function generateFooter(data) {
         result.push(`\t.WithIconUrl(${JSON.stringify(data.icon_url)})`);
     }
 
-    result[result.length-1] += ';\n\t});';
+    result[result.length-1] += ';\n\t})';
 
     return result.join('\n\t\t');
 }


### PR DESCRIPTION
These few things were causing errors due to invalid parameter types and an extra semicolon which wasn't needed.