### PR TITLE
Added support to for username and avatar_url in webhook mode

### DIFF
--- a/src/components/app.jsx
+++ b/src/components/app.jsx
@@ -223,6 +223,8 @@ const App = React.createClass({
             </div>
             <div className='vh-100 h-auto-l w-100 w-50-l pa4 pl3-l pb0'>
               <DiscordView
+                username={this.state.data.username}
+                avatar_url={this.state.data.avatar_url}
                 data={this.state.data}
                 error={this.state.error}
                 webhookMode={this.state.webhookMode}


### PR DESCRIPTION
This change makes the visualizer change the username and avatar of the bot when using webhook mode.

![image](https://user-images.githubusercontent.com/12865379/56776179-9c29bf80-677f-11e9-915b-d8ac70838a93.png)
