### PR TITLE
Update Discord.Net inline field snippet

### DIFF
--- a/src/snippets/discordnet.js
+++ b/src/snippets/discordnet.js
@@ -44,7 +44,7 @@ function generateAuthor(data) {
 function generateFields(data) {
     return data.map(function(x) {
         if (x.inline) {
-            return `\t.AddInlineField(${JSON.stringify(x.name)}, ${JSON.stringify(x.value)})`
+            return `\t.AddField(${JSON.stringify(x.name)}, ${JSON.stringify(x.value)}, true)`
         } else {
             return `\t.AddField(${JSON.stringify(x.name)}, ${JSON.stringify(x.value)})`
         }


### PR DESCRIPTION
We removed the AddInlineField method in favor of a boolean arg on the AddField method. Updating the snippet generation to reflect this.