### PR TITLE
Create support for discordPHP

### DIFF
--- a/src/components/codemodal.jsx
+++ b/src/components/codemodal.jsx
@@ -14,6 +14,7 @@ import restcord from '../snippets/restcord';
 import eris from '../snippets/eris';
 import discordrb from '../snippets/discordrb';
 import jda from '../snippets/jda';
+import discordphp from '../snippets/discordphp';
 
 
 const libraries = {
@@ -29,6 +30,7 @@ const libraries = {
   'ruby_discordrb': discordrb,
   'java_discord4j': discord4j,
   'java_jda': jda,
+  'php_discordphp': discordphp,
 };
 
 // TODO: check for localStorage availability?

--- a/src/snippets/discordphp.js
+++ b/src/snippets/discordphp.js
@@ -1,0 +1,20 @@
+export default {
+  name: 'DiscordPHP (PHP)',
+  language: 'php',
+  generateFrom(data) {
+    let embed = null;
+    if (data.embed) {
+      embed = JSON.stringify(data.embed, null, 4)
+        .replace(/{/g, '[')
+        .replace(/}/g, ']')
+        .replace(/^ {4}/gm, '        ')
+        .replace(/^]/gm, '    ]')
+        .replace(/":/g, '" =>')
+    }
+
+    return `<?php
+
+$message->channel->sendMessage('${data.content}', false, ${embed});`;
+
+  }
+};


### PR DESCRIPTION
Hello world!
I tried your embed visualizer and I really liked it! Then, I tried to export my embed to PHP but only saw RestCord and I use discordPHP :(
So I decided to code `discordphp.js` to support the new library discordPHP.
Sorry for my bad english.
Hope you push it!