### PR TITLE
Remove usage of deprecated method

### DIFF
--- a/src/snippets/jda.js
+++ b/src/snippets/jda.js
@@ -11,7 +11,7 @@ export default {
     }
 
     if (data.embed) {
-      result.push(`  .setEmbed(new EmbedBuilder()`);
+      result.push(`  .setEmbeds(new EmbedBuilder()`);
 
       if (data.embed.title) {
         const title = JSON.stringify(data.embed.title);


### PR DESCRIPTION
JDA deprecated the `MessageBuilder#setEmbed` method and introduced a `MessageBuilder#setEmbeds` method to support multiple embeds on a single message (DV8FromTheWorld/JDA#1871).